### PR TITLE
Update Buffer usage to prevent deprecation warning

### DIFF
--- a/splunk-cloudwatch-logs-processor/index.js
+++ b/splunk-cloudwatch-logs-processor/index.js
@@ -37,7 +37,7 @@ exports.handler = (event, context, callback) => {
     configureLogger(context, callback); // eslint-disable-line no-use-before-define
 
     // CloudWatch Logs data is base64 encoded so decode here
-    const payload = new Buffer(event.awslogs.data, 'base64');
+    const payload = new Buffer.from(event.awslogs.data, 'base64');
     // CloudWatch Logs are gzip compressed so expand here
     zlib.gunzip(payload, (error, result) => {
         if (error) {


### PR DESCRIPTION
AWS Lambda NodeJS 8.x is EOL, so we can safely update all the code to be ready for NodeJS 10.x
See #10 